### PR TITLE
Fix admin logs gateway path

### DIFF
--- a/backend/src/admin/admin-logs.gateway.ts
+++ b/backend/src/admin/admin-logs.gateway.ts
@@ -8,7 +8,9 @@ import {
 import { Server, WebSocket } from 'ws'; // Используем ws, не socket.io!
 
 @WebSocketGateway({
-  namespace: '/admin/logs', // Фронтенд должен подключаться: ws://host:port/admin/logs
+  // Используем путь вместо namespace, так как WsAdapter не поддерживает namespace
+  // Клиент подключается по адресу ws://host:port/admin/logs
+  path: '/admin/logs',
   cors: {
     origin: '*', // Лучше потом ограничить
     credentials: false,


### PR DESCRIPTION
## Summary
- use WebSocket `path` option instead of unsupported namespace

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684874eb6514832c91d22f10305889a3