### PR TITLE
Fix admin logs WebSocket path

### DIFF
--- a/backend/src/admin/admin-logs.gateway.ts
+++ b/backend/src/admin/admin-logs.gateway.ts
@@ -5,10 +5,11 @@ import {
   OnGatewayConnection,
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
-import { Server, WebSocket } from 'ws'; // Используем ws, не socket.io!
+import { Server, WebSocket } from 'ws';
 
 @WebSocketGateway({
-  namespace: '/admin/logs', // Фронтенд должен подключаться: ws://host:port/admin/logs
+  // "namespace" не поддерживается WsAdapter, используем "path" вместо этого
+  path: '/admin/logs', // Фронтенд подключается: ws://host:port/admin/logs
   cors: {
     origin: '*', // Лучше потом ограничить
     credentials: false,


### PR DESCRIPTION
## Summary
- use `path` option for AdminLogsGateway to keep WebSocket path with `WsAdapter`

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684881cb9994832cab2e2eed1938e2e1