### PR TITLE
Fix websocket logging before gateway ready

### DIFF
--- a/backend/src/admin/admin-logs.gateway.ts
+++ b/backend/src/admin/admin-logs.gateway.ts
@@ -39,6 +39,10 @@ export class AdminLogsGateway implements OnGatewayInit, OnGatewayConnection, OnG
 
   // Вызывай этот метод из сервисов для рассылки сообщений по логам
   sendLog(message: string) {
+    // Если сервер ещё не инициализирован, просто игнорируем
+    if (!this.server) {
+      return;
+    }
     for (const client of this.server.clients) {
       // У ws есть readyState константы (0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED)
       if (client.readyState === client.OPEN) {


### PR DESCRIPTION
## Summary
- handle uninitialized websocket server when sending logs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488525c56c832ca9db010a19bc62a4