### PR TITLE
Fix notification read permissions

### DIFF
--- a/backend/src/notifications/notification.controller.ts
+++ b/backend/src/notifications/notification.controller.ts
@@ -51,8 +51,13 @@ export class NotificationController {
    * Отметить уведомление как прочитанное.
    */
   @Patch(':id/read')
-  async markAsRead(@Param('id') id: string) {
-    return this.notificationService.markAsRead(id);
+  async markAsRead(@Param('id') id: string, @Req() req: Request) {
+    const user = req.user as any;
+    const userId = user.userId ?? user.id;
+    if (!userId) {
+      throw new UnauthorizedException('Пользователь не авторизован');
+    }
+    return this.notificationService.markAsRead(id, userId);
   }
 
   /**


### PR DESCRIPTION
## Summary
- restrict marking notifications as read to the recipient

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684888662860832c856a185054144286