### PR TITLE
Fix admin notifications API paths

### DIFF
--- a/frontend/app/admin/notifications/page.tsx
+++ b/frontend/app/admin/notifications/page.tsx
@@ -24,8 +24,8 @@ export default function AdminNotificationsPage() {
     const fetchData = async () => {
       try {
         const [notifRes, countRes] = await Promise.all([
-          axios.get('/notifications', { withCredentials: true }),
-          axios.get('/notifications/unread-count', { withCredentials: true }),
+          axios.get('/api/notifications', { withCredentials: true }),
+          axios.get('/api/notifications/unread-count', { withCredentials: true }),
         ]);
 
         setNotifications(notifRes.data);
@@ -42,7 +42,7 @@ export default function AdminNotificationsPage() {
 
   const markAsRead = async (id: string) => {
     try {
-      await axios.patch(`/notifications/${id}/read`, {}, { withCredentials: true });
+      await axios.patch(`/api/notifications/${id}/read`, {}, { withCredentials: true });
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? { ...n, isRead: true } : n))
       );


### PR DESCRIPTION
## Summary
- fix wrong axios paths in admin notifications page to use `/api` prefix

## Testing
- `npm test` *(fails: Module '@prisma/client' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_68488cd23014832cb89605a39bba3489