### PR TITLE
Add monitoring page and backend API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -96,3 +96,21 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+
+## Monitoring endpoint
+
+The `/admin/monitoring` route provides basic equipment health information.
+It pings each device's `ipAddress` and returns an array of objects:
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Server 1",
+    "ipAddress": "192.168.0.10",
+    "status": "online"
+  }
+]
+```
+
+Use this endpoint from the admin panel to display current status and receive live log updates via the `/admin/logs` WebSocket namespace.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.0.1",
         "@nestjs/websockets": "^11.0.1",
-        "@prisma/client": "^6.9.0",
+        "@prisma/client": "^6.7.0",
         "axios": "^1.6.7",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
@@ -33,6 +33,8 @@
         "node-telegram-bot-api": "^0.61.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
+        "ping": "^0.4.4",
+        "prisma": "^6.7.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.7.5",
@@ -68,7 +70,6 @@
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "prettier": "^3.4.2",
-        "prisma": "^6.9.0",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
@@ -3224,7 +3225,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
       "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jiti": "2.4.2"
@@ -3234,14 +3234,12 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
       "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
       "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3255,14 +3253,12 @@
       "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
       "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
       "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.9.0",
@@ -3274,7 +3270,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
       "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.9.0"
@@ -10382,7 +10377,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -11771,6 +11765,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/ping": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ping/-/ping-0.4.4.tgz",
+      "integrity": "sha512-56ZMC0j7SCsMMLdOoUg12VZCfj/+ZO+yfOSjaNCRrmZZr6GLbN2X/Ui56T15dI8NhiHckaw5X2pvyfAomanwqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -11949,7 +11952,6 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
       "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,16 +42,17 @@
     "express": "^4.18.4",
     "jwt-decode": "^4.0.0",
     "multer": "^1.4.5-lts.1",
+    "nestjs-telegraf": "^2.9.1",
     "node-telegram-bot-api": "^0.61.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "ping": "^0.4.4",
+    "prisma": "^6.7.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.8.1",
-    "telegraf": "^4.12.3",
-    "nestjs-telegraf": "^2.9.1",
-    "prisma": "^6.7.0"
+    "telegraf": "^4.12.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -92,13 +93,19 @@
     "typescript-eslint": "^8.20.0"
   },
   "jest": {
-    "moduleFileExtensions": ["js", "json", "ts"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "collectCoverageFrom": ["**/*.(t|j)s"],
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
   }

--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -1,0 +1,31 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { TelegramService } from '../telegram/telegram.service';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  const mockAdminService = { getMonitoring: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        { provide: AdminService, useValue: mockAdminService },
+        { provide: TelegramService, useValue: {} },
+      ],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return monitoring data', async () => {
+    const result = [{ id: 1, name: 'PC', status: 'online' }];
+    mockAdminService.getMonitoring.mockResolvedValue(result);
+    await expect(controller.getMonitoring()).resolves.toEqual(result);
+  });
+});

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -75,4 +75,10 @@ export class AdminController {
   async getHourlyActivity() {
     return this.adminService.getHourlyActivity();
   }
+
+  @Get('monitoring')
+  @Roles('admin', 'superuser')
+  async getMonitoring() {
+    return this.adminService.getMonitoring();
+  }
 }

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -7,6 +9,10 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: UsersService, useValue: {} },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,12 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: {} },
+        { provide: JwtService, useValue: {} },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { NotificationService } from '../notifications/notification.service';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -21,6 +22,7 @@ describe('UsersService', () => {
       providers: [
         UsersService,
         { provide: PrismaService, useValue: mockPrismaService },
+        { provide: NotificationService, useValue: {} },
       ],
     }).compile();
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -22,7 +22,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false,
-    "types": ["node"],
+    "types": ["node", "jest"],
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*"],

--- a/frontend/app/admin/monitoring/page.tsx
+++ b/frontend/app/admin/monitoring/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState, useRef } from 'react';
+import AdminNavbar from '@/components/AdminNavbar';
+import { MonitorSmartphone, TerminalSquare } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+interface MonitorItem {
+  id: number;
+  name: string;
+  ipAddress?: string | null;
+  status: string;
+}
+
+export default function AdminMonitoringPage() {
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
+  const [equipment, setEquipment] = useState<MonitorItem[]>([]);
+  const [logs, setLogs] = useState<string[]>([]);
+  const logRef = useRef<HTMLDivElement>(null);
+
+  const fetchStatus = async () => {
+    try {
+      const token = localStorage.getItem('token');
+      const res = await fetch(`${API_URL}/admin/monitoring`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      const data = await res.json();
+      setEquipment(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('Ошибка загрузки статусов', err);
+      setEquipment([]);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatus();
+  }, []);
+
+  useEffect(() => {
+    let ws: WebSocket | null = null;
+    try {
+      ws = new WebSocket(`ws://${window.location.hostname}:3000/admin/logs`);
+      ws.onmessage = (e) => {
+        setLogs((prev) => [...prev.slice(-29), e.data]);
+        setTimeout(() => {
+          if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+        }, 50);
+      };
+    } catch (err) {
+      console.error('WebSocket error', err);
+    }
+    return () => { if (ws) ws.close(); };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#13151e] via-[#182232] to-[#212e43] text-white pt-20 px-3 md:px-10 py-10">
+      <AdminNavbar />
+      <div className="max-w-5xl mx-auto space-y-10 mt-8">
+        <div className="flex items-center gap-3">
+          <MonitorSmartphone className="w-8 h-8 text-cyan-400" />
+          <h1 className="text-3xl md:text-4xl font-bold text-cyan-200">Мониторинг</h1>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="bg-white/10 border border-white/15 backdrop-blur-2xl rounded-2xl p-6 shadow-xl space-y-2"
+        >
+          <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+            <MonitorSmartphone className="w-5 h-5 text-cyan-400" /> Статус оборудования
+          </h2>
+          {equipment.length === 0 ? (
+            <div className="text-white/60">Нет данных</div>
+          ) : (
+            equipment.map((item) => (
+              <div key={item.id} className="flex justify-between items-center bg-white/5 px-4 py-2 rounded-xl">
+                <span>{item.name}{item.ipAddress ? ` (${item.ipAddress})` : ''}</span>
+                <span className={`text-sm font-semibold ${item.status === 'online' ? 'text-green-400' : 'text-red-400'}`}>
+                  {item.status === 'online' ? '🟢 Онлайн' : '🔴 Оффлайн'}
+                </span>
+              </div>
+            ))
+          )}
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="bg-white/10 border border-white/15 backdrop-blur-2xl rounded-2xl p-6 shadow-xl"
+        >
+          <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+            <TerminalSquare className="w-5 h-5 text-cyan-400" /> Последние логи
+          </h2>
+          <div ref={logRef} className="h-64 overflow-y-auto bg-black/40 rounded-xl p-3 text-sm font-mono text-white/80 space-y-1">
+            {logs.length === 0 ? (
+              <div className="text-white/60">Нет событий</div>
+            ) : (
+              logs.map((log, idx) => <div key={idx}>{log}</div>)
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/AdminNavbar.tsx
+++ b/frontend/components/AdminNavbar.tsx
@@ -22,6 +22,7 @@ const navItems = [
   { label: 'Заявки', href: '/admin/requests' },
   { label: 'Уведомления', href: '/admin/notifications' },
   { label: 'Новости', href: '/admin/news' },
+  { label: 'Мониторинг', href: '/admin/monitoring' },
 ];
 
 export default function AdminNavbar() {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,64 +1,14 @@
-diff --git a/backend/src/admin/admin-logs.gateway.ts b/backend/src/admin/admin-logs.gateway.ts
-index 365cabd2903d795e21eda29c227da273325375ea..e6f35434f917e99689e8078c77e13254cfb0f246 100644
---- a/backend/src/admin/admin-logs.gateway.ts
-+++ b/backend/src/admin/admin-logs.gateway.ts
-@@ -1,48 +1,49 @@
- import {
-   WebSocketGateway,
-   WebSocketServer,
-   OnGatewayInit,
-   OnGatewayConnection,
-   OnGatewayDisconnect,
- } from '@nestjs/websockets';
- import { Server, WebSocket } from 'ws'; // Используем ws, не socket.io!
- 
- @WebSocketGateway({
-   namespace: '/admin/logs', // Фронтенд должен подключаться: ws://host:port/admin/logs
-   cors: {
-     origin: '*', // Лучше потом ограничить
-     credentials: false,
-   },
- })
- export class AdminLogsGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
--  @WebSocketServer()
--  server: Server;
-+  @WebSocketServer()
-+  server?: Server;
- 
-   afterInit(server: Server) {
-     console.log('[WS] /admin/logs initialized');
-   }
- 
-   handleConnection(client: WebSocket) {
-     console.log('[WS] Новый клиент подключился к live-логам');
-     // Приветствие (можно удалить по вкусу)
-     try {
-       client.send('🟢 Live-лог подключен');
-     } catch (e) {
-       // ignore
-     }
-   }
- 
-   handleDisconnect(client: WebSocket) {
-     console.log('[WS] Клиент live-логов отключился');
-   }
- 
-   // Вызывай этот метод из сервисов для рассылки сообщений по логам
--  sendLog(message: string) {
--    for (const client of this.server.clients) {
--      // У ws есть readyState константы (0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED)
--      if (client.readyState === client.OPEN) {
--        client.send(message);
--      }
--    }
--  }
-+  sendLog(message: string) {
-+    if (!this.server) return;
-+    for (const client of this.server.clients) {
-+      // У ws есть readyState константы (0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED)
-+      if (client.readyState === client.OPEN) {
-+        client.send(message);
-+      }
-+    }
-+  }
- }
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://backend:3000/:path*',
+      },
+    ]
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
## Summary
- add monitoring admin page in frontend
- include monitoring link in admin navbar
- implement admin monitoring endpoint with ping-based status
- document monitoring API usage
- update unit tests and config

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684895f8c788832ca18c3a5a0d4322c3