### PR TITLE
Add Swagger documentation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,10 @@ $ npm run test:e2e
 # test coverage
 $ npm run test:cov
 ```
+## API Documentation
+
+Swagger UI is available at `/api/docs` when the application is running.
+
 
 ## Deployment
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,6 +39,8 @@
         "rxjs": "^7.8.1",
         "socket.io": "^4.7.5",
         "socket.io-client": "^4.8.1",
+        "@nestjs/swagger": "^7.2.7",
+        "swagger-ui-express": "^4.7.2",
         "telegraf": "^4.12.3"
       },
       "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,8 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.0.1",
     "@nestjs/websockets": "^11.0.1",
+    "@nestjs/swagger": "^7.2.7",
+    "swagger-ui-express": "^4.7.2",
     "@prisma/client": "^6.7.0",
     "axios": "^1.6.7",
     "bcrypt": "^5.1.1",

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Req, UseGuards, ForbiddenException } from '@nestjs/com
 import { AdminService } from './admin.service';
 import { TelegramService } from '../telegram/telegram.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
 // --- Пример простого кастомного декоратора для ролей ---
 function Roles(...roles: string[]) {
@@ -23,6 +24,8 @@ class RolesGuard implements CanActivate {
   }
 }
 
+@ApiTags('admin')
+@ApiBearerAuth()
 @Controller('admin')
 @UseGuards(JwtAuthGuard, RolesGuard) // <--- Добавил универсальный guard!
 export class AdminController {

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('app')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -12,7 +12,9 @@ import { Response } from 'express';
 
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(

--- a/backend/src/equipment/equipment.controller.ts
+++ b/backend/src/equipment/equipment.controller.ts
@@ -22,7 +22,10 @@ import { Express } from 'express';
 import { Roles } from '../auth/roles.decorator';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { UpdateEquipmentDto } from './dto/update-equipment.dto';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
+@ApiTags('equipment')
+@ApiBearerAuth()
 @Controller('equipment')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class EquipmentController {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,7 @@ import { ValidationPipe } from '@nestjs/common';
 import * as fs from 'fs';
 import { PrismaService } from './prisma/prisma.service';
 import { AdminLogsGateway } from './admin/admin-logs.gateway';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
   // Загружаем .env вручную, чтобы быть уверенным
@@ -87,6 +88,15 @@ async function bootstrap() {
     credentials: true,
     allowedHeaders: 'Content-Type, Authorization, Cookie',
   });
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('IT Otdel API')
+    .setDescription('API documentation')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api/docs', app, swaggerDocument);
 
   const port = process.env.PORT || 3000;
 

--- a/backend/src/news/news.controller.ts
+++ b/backend/src/news/news.controller.ts
@@ -16,7 +16,10 @@ import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { CreateNewsDto } from './dto/create-news.dto';
 import { UpdateNewsDto } from './dto/update-news.dto';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
+@ApiTags('news')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('news')
 export class NewsController {

--- a/backend/src/notifications/notification.controller.ts
+++ b/backend/src/notifications/notification.controller.ts
@@ -15,7 +15,10 @@ import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Request } from 'express';
 import { CreateNotificationDto } from './dto/create-notification.dto';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
+@ApiTags('notifications')
+@ApiBearerAuth()
 @Controller('notifications')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class NotificationController {

--- a/backend/src/requests/comments.controller.ts
+++ b/backend/src/requests/comments.controller.ts
@@ -13,7 +13,10 @@ import {
 import { CommentsService } from './comments.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Request } from 'express';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
+@ApiTags('requests')
+@ApiBearerAuth()
 @Controller('requests/:requestId/comments')
 @UseGuards(JwtAuthGuard)
 export class CommentsController {

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -27,6 +27,7 @@ import { CreateCommentDto } from './dto/create-comment.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
 const uploadPath = resolve('./uploads');
 
@@ -38,6 +39,8 @@ function fileFilter(req, file, cb) {
   cb(null, true);
 }
 
+@ApiTags('requests')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('requests')
 export class RequestsController {

--- a/backend/src/software/software.controller.ts
+++ b/backend/src/software/software.controller.ts
@@ -17,7 +17,10 @@ import { UpdateSoftwareDto } from './dto/update-software.dto';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
+@ApiTags('software')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('software')
 export class SoftwareController {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -8,7 +8,10 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 
+@ApiTags('users')
+@ApiBearerAuth()
 @Controller('users')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class UsersController {


### PR DESCRIPTION
## Summary
- integrate `@nestjs/swagger` and `swagger-ui-express`
- expose docs at `/api/docs`
- annotate controllers with Swagger decorators
- mention docs location in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1bbb9770832ca871bdc6db79971c