### PR TITLE
Fix npm install reliability during Docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,8 +14,11 @@ COPY package.json package-lock.json* ./
 # Копирование схемы Prisma
 COPY prisma ./prisma
 
-# Установка прод-зависимостей
-RUN npm install --legacy-peer-deps
+# Установка прод-зависимостей c увеличенными таймаутами скачивания
+RUN npm config set fetch-retry-maxtimeout 600000 \
+    && npm config set fetch-retry-mintimeout 20000 \
+    && npm config set fetch-retries 5 \
+    && npm install --legacy-peer-deps
 
 # Копирование исходников проекта
 COPY . .


### PR DESCRIPTION
## Summary
- configure npm fetch retry settings in `backend/Dockerfile` to improve build reliability

## Testing
- `npm install --legacy-peer-deps` *(fails: ETARGET No matching version found for swagger-ui-express@^4.7.2)*

------
https://chatgpt.com/codex/tasks/task_e_684b31896fe4832c8cd314fc0aa1e785