### PR TITLE
Fix Swagger dependency and revert Dockerfile

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,7 +40,7 @@
         "socket.io": "^4.7.5",
         "socket.io-client": "^4.8.1",
         "@nestjs/swagger": "^7.2.7",
-        "swagger-ui-express": "^4.7.2",
+        "swagger-ui-express": "^5.0.1",
         "telegraf": "^4.12.3"
       },
       "devDependencies": {
@@ -13667,6 +13667,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,7 @@
     "@nestjs/platform-socket.io": "^11.0.1",
     "@nestjs/websockets": "^11.0.1",
     "@nestjs/swagger": "^7.2.7",
-    "swagger-ui-express": "^4.7.2",
+    "swagger-ui-express": "^5.0.1",
     "@prisma/client": "^6.7.0",
     "axios": "^1.6.7",
     "bcrypt": "^5.1.1",


### PR DESCRIPTION
## Summary
- keep Dockerfile simple by removing npm retry logic
- update package-lock for swagger-ui-express 5.0.1 with minimal diff

## Testing
- `npm install --legacy-peer-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b31896fe4832c8cd314fc0aa1e785