### PR TITLE
Implement JWT secret check and rate limiting

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,11 @@
 $ npm install
 ```
 
+## Environment variables
+
+Set `JWT_SECRET` in your environment or `.env` file before starting the server.
+The application will refuse to run without it.
+
 ## Compile and run the project
 
 ```bash

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { ConfigModule } from '@nestjs/config';
 
 import { AppController } from './app.controller';
@@ -22,6 +24,7 @@ import { AdminLogsGateway } from './admin/admin-logs.gateway'; // 👈 Доба�
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    ThrottlerModule.forRoot({ ttl: 60, limit: 20 }),
     PrismaModule,
     AuthModule,
     UsersModule,
@@ -37,6 +40,10 @@ import { AdminLogsGateway } from './admin/admin-logs.gateway'; // 👈 Доба�
   providers: [
     AppService,
     AdminLogsGateway, // 👈 Добавлен gateway для Live-логов!
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import { Response } from 'express';
 
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { Throttle } from '@nestjs/throttler';
 
 @Controller('auth')
 export class AuthController {
@@ -21,6 +22,7 @@ export class AuthController {
   ) {}
 
   @Post('register')
+  @Throttle({ default: { limit: 5, ttl: 60 } })
   @HttpCode(201)
   async register(@Body() body: RegisterDto) {
     const birthDate = new Date(body.birthDate);
@@ -38,6 +40,7 @@ export class AuthController {
   }
 
   @Post('login')
+  @Throttle({ default: { limit: 5, ttl: 60 } })
   @HttpCode(200)
   async login(
     @Body() body: LoginDto,

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -18,6 +18,10 @@ interface JwtPayload {
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor() {
+    const jwtSecret = process.env.JWT_SECRET;
+    if (!jwtSecret) {
+      throw new Error('JWT_SECRET env variable is required');
+    }
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (req: Request) => {
@@ -30,7 +34,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         },
       ]),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'supersecretkey',
+      secretOrKey: jwtSecret,
     });
   }
 


### PR DESCRIPTION
## Summary
- enforce presence of `JWT_SECRET` in JwtStrategy
- limit auth endpoints via `@nestjs/throttler`
- register `ThrottlerModule` globally and set guard
- document required `JWT_SECRET` env variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f089ec4b8832c83fe69f041bf0a1d