### PR TITLE
Fix lockfile and throttle dependency

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,9 +15,7 @@ COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 
 # Установка прод-зависимостей
-ENV NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
-    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
-RUN npm install --legacy-peer-deps --unsafe-perm
+RUN npm install --legacy-peer-deps
 
 # Копирование исходников проекта
 COPY . .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,9 @@ COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 
 # Установка прод-зависимостей
-RUN npm install --legacy-peer-deps
+ENV NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
+RUN npm install --legacy-peer-deps --unsafe-perm
 
 # Копирование исходников проекта
 COPY . .

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.0.1",
+        "@nestjs/throttler": "^6.4.0",
         "@nestjs/websockets": "^11.0.1",
         "@prisma/client": "^6.7.0",
         "axios": "^1.6.7",
@@ -3084,6 +3085,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/websockets": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.0.1",
+    "@nestjs/throttler": "^6.4.0",
     "@nestjs/websockets": "^11.0.1",
     "@prisma/client": "^6.7.0",
     "axios": "^1.6.7",


### PR DESCRIPTION
## Summary
- restore old lockfile format
- add `@nestjs/throttler` dependency for backend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0d44bfbc832c89a1397d42a95105